### PR TITLE
Remove BranchId from BranchRole for global roles

### DIFF
--- a/HOMMS.Application/Implementations/AuthService.cs
+++ b/HOMMS.Application/Implementations/AuthService.cs
@@ -232,10 +232,16 @@ namespace HOMMS.Application.Implementations
                 var roles = await _userManager.GetRolesAsync(user);
                 if (roles.Contains("SystemAdmin"))
                 {
-                    // Get all permissions from the branch's roles
+                    // Get all permissions from roles associated with this branch
                     var branchPermissions = await _context.BranchRoles
-                        .Where(br => br.BranchId == branchId && !br.IsDeleted && !string.IsNullOrEmpty(br.Permissions))
+                        .Where(br => !br.IsDeleted && 
+                                   !string.IsNullOrEmpty(br.Permissions) &&
+                                   _context.BranchUserRoles.Any(bur => 
+                                       bur.BranchRoleId == br.Id && 
+                                       bur.BranchId == branchId && 
+                                       !bur.IsDeleted))
                         .Select(br => br.Permissions)
+                        .Distinct()
                         .ToListAsync();
 
                     var uniquePermissions = new HashSet<string>();

--- a/HOMMS.Application/Implementations/BranchRoleManagementService.cs
+++ b/HOMMS.Application/Implementations/BranchRoleManagementService.cs
@@ -18,13 +18,13 @@ namespace HOMMS.Application.Implementations
         {
             _repository = repository;
         }
-        private BranchRoleDto MapToDto(BranchRole entity)
+        private BranchRoleDto MapToDto(BranchRole entity, int? branchId = null)
         {
             return new BranchRoleDto
             {
                 Id = entity.Id,
                 Name = entity.Name,
-                BranchId = entity.BranchId,
+                BranchId = branchId ?? 0, // Will be set from context when needed
                 IsDefault = entity.IsDefault,
                 Permissions = string.IsNullOrEmpty(entity.Permissions)
                     ? new List<string>()
@@ -36,7 +36,6 @@ namespace HOMMS.Application.Implementations
             return new BranchRole
             {
                 Name = dto.Name,
-                BranchId = dto.BranchId,
                 IsDefault = dto.IsDefault,
                 Permissions = dto.Permissions != null
                     ? string.Join(",", dto.Permissions)
@@ -47,7 +46,6 @@ namespace HOMMS.Application.Implementations
         private void UpdateEntityFromDto(BranchRole entity, BranchRoleCreateUpdateDto dto)
         {
             entity.Name = dto.Name;
-            entity.BranchId = dto.BranchId;
             entity.IsDefault = dto.IsDefault;
             entity.Permissions = dto.Permissions != null
                 ? string.Join(",", dto.Permissions)
@@ -56,13 +54,21 @@ namespace HOMMS.Application.Implementations
 
         public async Task<IEnumerable<BranchRoleDto>> GetByBranchAsync(int branchId, string? keyword = null)
         {
-            var roles = await _repository.GetByAsync(r =>
-                r.BranchId == branchId &&
-                !r.IsDeleted &&
-                r.Name != "Admin System" &&
-                (string.IsNullOrEmpty(keyword) || r.Name.Contains(keyword)));
+            List<BranchRole> roles;
+            
+            if (string.IsNullOrEmpty(keyword))
+            {
+                roles = await _repository.GetRolesByBranchIdAsync(branchId);
+            }
+            else
+            {
+                roles = await _repository.SearchRolesByBranchIdAsync(branchId, keyword);
+            }
 
-            return roles.Select(MapToDto);
+            // Filter out Admin System role and apply additional filters
+            var filteredRoles = roles.Where(r => r.Name != "Admin System");
+
+            return filteredRoles.Select(r => MapToDto(r, branchId));
         }
 
         public async Task<BranchRoleDto?> GetByIdAsync(int id)

--- a/HOMMS.Domain/Entities/Branch.cs
+++ b/HOMMS.Domain/Entities/Branch.cs
@@ -85,11 +85,6 @@ namespace HOMMS.Domain.Entities
         /// </summary>
         public virtual ICollection<FoodCategory> FoodCategories { get; set; } = new HashSet<FoodCategory>();
         
-        /// <summary>
-        /// Gets or sets the navigation property for branch roles
-        /// </summary>
-        public virtual ICollection<BranchRole> BranchRoles { get; set; } = new HashSet<BranchRole>();
-
         public virtual ICollection<SystemLog> SystemLogs { get; set; } = new HashSet<SystemLog>();
 
         /// <summary>

--- a/HOMMS.Domain/Entities/BranchRole.cs
+++ b/HOMMS.Domain/Entities/BranchRole.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations;
 namespace HOMMS.Domain.Entities
 {
     /// <summary>
-    /// Represents a branch-specific role with permissions
+    /// Represents a role with permissions that can be associated with branches through BranchUserRole
     /// </summary>
     public class BranchRole : BaseAuditableEntity<int>
     {
@@ -13,11 +13,9 @@ namespace HOMMS.Domain.Entities
         [StringLength(100)]
         public string Name { get; set; } = string.Empty;
 
-        public int BranchId { get; set; }
         public bool IsDefault { get; set; }
         public string Permissions { get; set; } = string.Empty; // Comma-separated
 
-        public virtual Branch? Branch { get; set; }
         public virtual ICollection<BranchUserRole> BranchUserRoles { get; set; } = new List<BranchUserRole>();
     }
 } 

--- a/HOMMS.Infrastructure/Configurations/BranchRoleConfiguration.cs
+++ b/HOMMS.Infrastructure/Configurations/BranchRoleConfiguration.cs
@@ -8,14 +8,13 @@ namespace HOMMS.Infrastructure.Configurations
     {
         public void Configure(EntityTypeBuilder<BranchRole> builder)
         {
-            builder.HasOne(br => br.Branch)
-                .WithMany(b => b.BranchRoles)
-                .HasForeignKey(br => br.BranchId)
-                .OnDelete(DeleteBehavior.Cascade);
-
+            // Configure the relationship with BranchUserRoles
             builder.HasMany(br => br.BranchUserRoles)
                 .WithOne(bur => bur.BranchRole)
                 .HasForeignKey(bur => bur.BranchRoleId);
+
+            // Note: BranchRole no longer has a direct relationship with Branch
+            // The association is now through BranchUserRole junction table
         }
     }
 } 

--- a/HOMMS.Infrastructure/Extensions/SeedExtensions.cs
+++ b/HOMMS.Infrastructure/Extensions/SeedExtensions.cs
@@ -49,8 +49,10 @@ namespace HOMMS.Infrastructure.Extensions
                     logger.LogInformation("Roles already exist. Skipping identity seeding.");
                 }
 
-                // Only seed branch roles if none exist for this branch
-                if (!await context.BranchRoles.AnyAsync(r => r.BranchId == branchId))
+                // Only seed branch roles if none exist for this branch (check via BranchUserRole associations)
+                var hasExistingRoles = await context.BranchUserRoles.AnyAsync(bur => 
+                    bur.BranchId == branchId && !bur.IsDeleted);
+                if (!hasExistingRoles)
                 {
                     logger.LogInformation("Seeding branch roles and permissions...");
                     await HOMMS.Infrastructure.Seeds.BranchRoleSeedData.SeedBranchRolesAsync(services, branchId);

--- a/HOMMS.Infrastructure/Migrations/20250817172413_RemoveBranchIdFromBranchRoles_ManuallyApplied.Designer.cs
+++ b/HOMMS.Infrastructure/Migrations/20250817172413_RemoveBranchIdFromBranchRoles_ManuallyApplied.Designer.cs
@@ -4,6 +4,7 @@ using HOMMS.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace HOMMS.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250817172413_RemoveBranchIdFromBranchRoles_ManuallyApplied")]
+    partial class RemoveBranchIdFromBranchRoles_ManuallyApplied
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HOMMS.Infrastructure/Migrations/20250817172413_RemoveBranchIdFromBranchRoles_ManuallyApplied.cs
+++ b/HOMMS.Infrastructure/Migrations/20250817172413_RemoveBranchIdFromBranchRoles_ManuallyApplied.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HOMMS.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveBranchIdFromBranchRoles_ManuallyApplied : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_BranchRoles_Branches_BranchId",
+                table: "BranchRoles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_BranchRoles_BranchId",
+                table: "BranchRoles");
+
+            migrationBuilder.DropColumn(
+                name: "BranchId",
+                table: "BranchRoles");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "BranchId",
+                table: "BranchRoles",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BranchRoles_BranchId",
+                table: "BranchRoles",
+                column: "BranchId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_BranchRoles_Branches_BranchId",
+                table: "BranchRoles",
+                column: "BranchId",
+                principalTable: "Branches",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/HOMMS.Infrastructure/Repositories/Implementations/BranchRoleManagementRepository.cs
+++ b/HOMMS.Infrastructure/Repositories/Implementations/BranchRoleManagementRepository.cs
@@ -18,21 +18,29 @@ namespace HOMMS.Infrastructure.Repositories.Implementations
         {
             _context = dbContext;
         }
-        public async Task<List<BranchRole>> GetByBranchIdAsync(int branchId)
+        public async Task<List<BranchRole>> GetRolesByBranchIdAsync(int branchId)
         {
+            // Get distinct roles that are associated with the specified branch through BranchUserRole
             return await _context.BranchRoles
-                .Where(r => r.BranchId == branchId && !r.IsDeleted)
+                .Where(r => !r.IsDeleted &&
+                           _context.BranchUserRoles.Any(bur => 
+                               bur.BranchRoleId == r.Id && 
+                               bur.BranchId == branchId && 
+                               !bur.IsDeleted))
                 .OrderBy(r => r.CreatedAt)
                 .ToListAsync();
         }
 
-        public async Task<List<BranchRole>> SearchAsync(int branchId, string keyword)
+        public async Task<List<BranchRole>> SearchRolesByBranchIdAsync(int branchId, string keyword)
         {
+            // Get distinct roles that are associated with the specified branch through BranchUserRole and match keyword
             return await _context.BranchRoles
-                .Where(r =>
-                    r.BranchId == branchId &&
-                    !r.IsDeleted &&
-                    EF.Functions.Like(r.Name, $"%{keyword}%"))
+                .Where(r => !r.IsDeleted &&
+                           EF.Functions.Like(r.Name, $"%{keyword}%") &&
+                           _context.BranchUserRoles.Any(bur => 
+                               bur.BranchRoleId == r.Id && 
+                               bur.BranchId == branchId && 
+                               !bur.IsDeleted))
                 .ToListAsync();
         }
 

--- a/HOMMS.Infrastructure/Repositories/Implementations/BranchUserManagementRepository.cs
+++ b/HOMMS.Infrastructure/Repositories/Implementations/BranchUserManagementRepository.cs
@@ -143,7 +143,7 @@ namespace HOMMS.Infrastructure.Repositories.Implementations
                             on new { UserId = u.Id, BranchId = (int?)bu.BranchId }
                             equals new {bur.UserId, bur.BranchId }
                           join br in _context.BranchRoles on bur.BranchRoleId equals br.Id
-                          where !bu.IsDeleted && bu.BranchId == branchId
+                          where !bu.IsDeleted && bu.BranchId == branchId && br.Name != "Admin System"
                           orderby bu.CreatedAt descending
                           select new UserDto
                           {

--- a/HOMMS.Infrastructure/Repositories/Interfaces/IBranchRoleManagementRepository.cs
+++ b/HOMMS.Infrastructure/Repositories/Interfaces/IBranchRoleManagementRepository.cs
@@ -9,8 +9,8 @@ namespace HOMMS.Infrastructure.Repositories.Interfaces
 {
     public interface IBranchRoleManagementRepository: IRepository<BranchRole, int>
     {
-        Task<List<BranchRole>> GetByBranchIdAsync(int branchId);
-        Task<List<BranchRole>> SearchAsync(int branchId, string keyword);
+        Task<List<BranchRole>> GetRolesByBranchIdAsync(int branchId);
+        Task<List<BranchRole>> SearchRolesByBranchIdAsync(int branchId, string keyword);
         Task<BranchRole?> GetByIdAsync(int id);
         Task<BranchRole> CreateAsync(BranchRole entity);
         Task<BranchRole?> UpdateAsync(int id, BranchRole entity);

--- a/HOMMS.Infrastructure/Seeds/BranchRoleSeedData.cs
+++ b/HOMMS.Infrastructure/Seeds/BranchRoleSeedData.cs
@@ -11,7 +11,7 @@ namespace HOMMS.Infrastructure.Seeds
 {
     public static class BranchRoleSeedData
     {
-        public static async Task SeedBranchRolesAsync(IServiceProvider serviceProvider, int branchId)
+        public static async Task SeedBranchRolesAsync(IServiceProvider serviceProvider, int branchId = 0)
         {
             using var scope = serviceProvider.CreateScope();
             var branchRoleRepo = scope.ServiceProvider.GetRequiredService<IRepository<BranchRole, int>>();
@@ -117,14 +117,13 @@ namespace HOMMS.Infrastructure.Seeds
                 "locations:delete"
             };
 
-            // Ensure only one Admin System BranchRole exists
-            var adminSystemRoleExists = (await branchRoleRepo.GetByAsync(r => r.Name == "Admin System" && r.BranchId == branchId)).Any();
+            // Ensure only one Admin System BranchRole exists globally
+            var adminSystemRoleExists = (await branchRoleRepo.GetByAsync(r => r.Name == "Admin System")).Any();
             if (!adminSystemRoleExists)
             {
                 var adminSystemRole = new BranchRole
                 {
                     Name = "Admin System",
-                    BranchId = branchId,
                     IsDefault = false,
                     Permissions = string.Join(",", allPermissions),
                     CreatedAt = DateTime.UtcNow
@@ -132,13 +131,12 @@ namespace HOMMS.Infrastructure.Seeds
                 await branchRoleRepo.AddAsync(adminSystemRole);
             }
 
-            // Seed predefined roles with appropriate permissions
+            // Seed predefined global roles with appropriate permissions
             var predefinedRoles = new List<BranchRole>
             {
                 new BranchRole
                 {
                     Name = "Quản lý chi nhánh",
-                    BranchId = branchId,
                     IsDefault = false,
                     Permissions = string.Join(",", new[]
                     {
@@ -161,7 +159,6 @@ namespace HOMMS.Infrastructure.Seeds
                 new BranchRole
                 {
                     Name = "Quản lý",
-                    BranchId = branchId,
                     IsDefault = true,
                     Permissions = string.Join(",", new[]
                     {
@@ -183,7 +180,6 @@ namespace HOMMS.Infrastructure.Seeds
                 new BranchRole
                 {
                     Name = "Thu Ngân",
-                    BranchId = branchId,
                     IsDefault = false,
                     Permissions = string.Join(",", new[]
                     {
@@ -200,7 +196,6 @@ namespace HOMMS.Infrastructure.Seeds
                 new BranchRole
                 {
                     Name = "Nhân viên",
-                    BranchId = branchId,
                     IsDefault = false,
                     Permissions = string.Join(",", new[]
                     {
@@ -216,7 +211,6 @@ namespace HOMMS.Infrastructure.Seeds
                 new BranchRole
                 {
                     Name = "Nhà bếp",
-                    BranchId = branchId,
                     IsDefault = false,
                     Permissions = string.Join(",", new[]
                     {
@@ -231,7 +225,6 @@ namespace HOMMS.Infrastructure.Seeds
                 new BranchRole
                 {
                     Name = "Y tá",
-                    BranchId = branchId,
                     IsDefault = false,
                     Permissions = string.Join(",", new[]
                     {
@@ -247,7 +240,7 @@ namespace HOMMS.Infrastructure.Seeds
             };
             foreach (var role in predefinedRoles)
             {
-                var exists = (await branchRoleRepo.GetByAsync(r => r.Name == role.Name && r.BranchId == branchId)).Any();
+                var exists = (await branchRoleRepo.GetByAsync(r => r.Name == role.Name)).Any();
                 if (!exists)
                     await branchRoleRepo.AddAsync(role);
             }

--- a/HOMMS.Infrastructure/Seeds/BranchUserRoleSeedData.cs
+++ b/HOMMS.Infrastructure/Seeds/BranchUserRoleSeedData.cs
@@ -99,11 +99,11 @@ namespace HOMMS.Infrastructure.Seeds
                 // Process each branch role for this user
                 foreach (var branchRoleName in branchRoleNames)
                 {
-                    // Find branch role
-                    var branchRole = (await branchRoleRepo.GetByAsync(br => br.Name == branchRoleName && br.BranchId == branchId)).FirstOrDefault();
+                    // Find branch role (roles are now global, not branch-specific)
+                    var branchRole = (await branchRoleRepo.GetByAsync(br => br.Name == branchRoleName)).FirstOrDefault();
                     if (branchRole == null)
                     {
-                        Console.WriteLine($"Warning: Branch role '{branchRoleName}' not found for branch {branchId}. Skipping.");
+                        Console.WriteLine($"Warning: Branch role '{branchRoleName}' not found. Skipping.");
                         continue;
                     }
 


### PR DESCRIPTION
This commit removes the `BranchId` property from the `BranchRole` entity, making it a global role not tied to any specific branch. Updates include modifying the `MapToDto` and `GetByBranchAsync` methods in `BranchRoleManagementService` to accommodate this change. The `BranchRoleManagementRepository` methods have been renamed to reflect the global nature of roles. Seeding logic in `BranchRoleSeedData` has been adjusted to create roles globally, and the `ApplicationDbContextModelSnapshot` has been updated accordingly. A migration file has been added to handle the database schema changes, and the `Branch` entity no longer references `BranchRoles`.